### PR TITLE
Remove duplicate word from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Temporal ridesharing demo application
 This repository contains code for a ridesharing demo application that 
 highlights Temporal's durability and support for external interactions.
-It's implemented in TypeScript and integrates with Stripe's 
+It's implemented in TypeScript and integrates with 
 [Stripe's usage-based billing](https://docs.stripe.com/billing/subscriptions/usage-based).
 Want to see it in action? Check out this demonstration from the Stripe 
 Sessions conference (the demo starts at 13:09):


### PR DESCRIPTION
I noticed that the README said "Stripe's" twice, once before the linked text and again within the linked text. This fixes the duplication by removing the first instance.