### PR TITLE
remove unnecessary parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are five steps to running the application:
 
 
 ### Set Up Usage-Based Billing in Stripe
-See ([this document](docs/stripe-setup.md) for step-by-step instructions 
+See [this document](docs/stripe-setup.md) for step-by-step instructions 
 for the prerequisite Stripe setup. 
 
 ### Start the Temporal Service


### PR DESCRIPTION
While reviewing the README, I noticed that it contained an unnecessary opening parenthesis. This PR removes it.